### PR TITLE
Use Services global variable if possible

### DIFF
--- a/api/implementation.js
+++ b/api/implementation.js
@@ -1,6 +1,8 @@
 var insertSignatureApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
-    const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm")
+    const Services = globalThis.Services || ChromeUtils.import(
+      "resource://gre/modules/Services.jsm"
+    ).Services
     // See: https://developer.mozilla.org/en/docs/Mozilla/Tech/XPCOM/Accessing_the_Windows_Registry_Using_XPCOM
 
     const wrkGenerator = () => (


### PR DESCRIPTION
Services.jsm is planned to be removed in Firefox 117 cycle in https://bugzilla.mozilla.org/show_bug.cgi?id=1780695 . Services global variable is available in WebExtensions experiments API global from version 88 https://bugzilla.mozilla.org/show_bug.cgi?id=1698158 , and experiments code doesn't have to import Services.jsm for recent versions.