### PR TITLE
update for 115 and removal of one Experiment

### DIFF
--- a/api/implementation.js
+++ b/api/implementation.js
@@ -31,21 +31,6 @@ var insertSignatureApi = class extends ExtensionCommon.ExtensionAPI {
     return {
       insertSignatureApi: {
         // test:
-        // await browser.insertSignatureApi.insertTextAtCurrentEditor({text:"hello"})
-        async insertTextAtCurrentEditor(options) {
-          const msgcompose = Services.wm.getMostRecentWindow("msgcompose")
-          const editor = msgcompose.GetCurrentEditor()
-
-          if(options.isHTML) {
-            editor.insertHTML(options.text)
-          }
-          else {
-            editor.insertText(options.text)
-          }
-
-          return {}
-        },
-        // test:
         // await browser.insertSignatureApi.importSignatureFromWindowsLiveMail()
         async importSignatureFromWindowsLiveMail() {
           const wrk = wrkGenerator()

--- a/api/schema.json
+++ b/api/schema.json
@@ -3,31 +3,6 @@
     "namespace": "insertSignatureApi",
     "functions": [
       {
-        "name": "insertTextAtCurrentEditor",
-        "type": "function",
-        "description": "Insert text at current editor",
-        "async": true,
-        "parameters": [
-          {
-            "name": "options",
-            "type": "object",
-            "description": "Various options other than text for future extension",
-            "properties": {
-              "text": {
-                "type": "string",
-                "description": "Text to be inserted",
-                "optional": false
-              },
-              "isHTML": {
-                "type": "boolean",
-                "description": "Text is HTML or plain",
-                "optional": false
-              }
-            }
-          }
-        ]
-      },
-      {
         "name": "importSignatureFromWindowsLiveMail",
         "type": "function",
         "description": "Import signatures from Windows Live Mail registry",

--- a/js/background.js
+++ b/js/background.js
@@ -1,0 +1,3 @@
+browser.composeScripts.register({
+    js: [{ file: "/js/composeScript.js" }],
+});

--- a/js/composeScript.js
+++ b/js/composeScript.js
@@ -1,0 +1,11 @@
+browser.runtime.onMessage.addListener((options, sender) => {
+    if (options.text) {
+        if(options.isHTML) {
+            document.execCommand("insertHtml", false, options.text);
+        }
+        else {
+            document.execCommand("insertText", false, options.text);
+        }
+    }
+    return Promise.resolve({});
+});

--- a/js/inserter.js
+++ b/js/inserter.js
@@ -37,8 +37,9 @@ function refreshTemplatesInserterListView() {
             return $('<li>')
               .append(
                 $('<a>')
-                  .on('click', () => {
-                    browser.insertSignatureApi.insertTextAtCurrentEditor({
+                  .on('click', async () => {
+                    let [composeTab] = await browser.tabs.query({currentWindow: true, type: "messageCompose"})
+                    await browser.tabs.sendMessage(composeTab.id, {
                       text: templateValue,
                       isHTML: pref.get(`set.html`) == "true"
                     })

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "applications": {
     "gecko": {
       "id": "InsertSignature@digitaldolphins.jp",

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,8 @@
   "applications": {
     "gecko": {
       "id": "InsertSignature@digitaldolphins.jp",
-      "strict_max_version": "102.*",
-      "strict_min_version": "68.6.0"
+      "strict_min_version": "68.6.0",
+      "strict_max_version": "115.*"
     }
   },
   "icons": {
@@ -31,6 +31,12 @@
     "default_popup": "inserter.html",
     "default_title": "__MSG_actionTitle__"
   },
+  "background": {
+    "scripts": ["js/background.js"]
+  },
+  "permissions": [
+    "compose"
+  ],
   "experiment_apis": {
     "insertSignatureApi": {
       "schema": "api/schema.json",


### PR DESCRIPTION
This PR tries to partially solve #6 . It replaces the `insertTextAtCurrentEditor()` Experiment method by a composeScript. I think it works as expected.

The second Experiment function `importSignatureFromWindowsLiveMail()` is not replaceable that easy.

You could either release a companion tool, which needs to be installed alongside your add-on, on the users windows system, which communicates with Thunderbird via native messaging. The companion tool is accessing the registry and forwards the data to the WebExtension.

Another alternative is to split your add-on and release a pure WebExtension version ("InsertSignature") without the Experiment A second add-on ("InsertSignature Windows LiveMail Extension" includes the Experiment, is reading the registry and forwards the data to the pure WebExtension. This way, users who do not need to import their Windows LiveMail signatures, can use the pure WebExtension. The other users can install "InsertSignature  Window Mail Extension".
