### PR TITLE
Remove strict_max_version manifest entry, which is needed only for Experiments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,11 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "applications": {
     "gecko": {
       "id": "InsertSignature@digitaldolphins.jp",
-      "strict_min_version": "68.6.0",
-      "strict_max_version": "116.*"
+      "strict_min_version": "68.6.0"
     }
   },
   "icons": {


### PR DESCRIPTION
Since your add-on is now a pure WebExtension, the `strict_max_version` manifest entry can be removed. It is only needed for Experiments, which could become incompatible with future versions of Thunderbird. WebExtensions on the other hand use stable WebExtension APIs and should not become incompatible.

If we ever DO have to introduce backward incompatible changes, we announce them on the add-on developer list. If you have not already joined, I highly suggest subscribing:
https://thunderbird.topicbox.com/groups/addons

I do want to use this opportunity to ask what you think about joining my team of enthusiastic add-on developers to help others with their updates. No pressure, feel free to say no.
https://thunderbird.topicbox.com/groups/addons/Tcbf4f23648b3346c/forming-a-team-of-enthusiastic-add-on-developers-to-help-others-with-their-updates